### PR TITLE
fix: remove ollama from compose, use internal db, restrict ports 3000 & 5000

### DIFF
--- a/.github/workflows/push_to_server.yml
+++ b/.github/workflows/push_to_server.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Check Runner User
         run: whoami
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # 2️⃣ Get runner IP and set as environment variable
       - name: Get Runner IP
         id: get_ip

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,54 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
 .env
-*.db
-# Local credentials and documentation — never commit
-Credentials and Deployment.pdf
-*.docx
-synerge-reader-backend/venv/
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+venv/
+.venv/
+
+# Claude local settings
+.claude/
+
+# Backup files
 *.backup_apr26
+
+# Local documents — never commit
+*.docx
+Credentials and Deployment.pdf
+
+# pdfQA evaluation — generated files, not source
+eval/source_pdfs/
+eval/results/
+eval/dataset.json
+eval/pdfs_needed.json
+
+# Database files
+*.db
+*.sqlite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,55 +1,49 @@
+name: synergereader
+
 networks:
   default:
     external: true
     name: agent_network
+
 services:
-  ollama:
-    image: ollama/ollama:latest
-    environment:
-      - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE}
-    ports:
-      - "127.0.0.1:11434:11434"
-    volumes:
-      - ollama_data:/root/.ollama
-    restart: unless-stopped
-  db:
+  synergereader-db:
     image: pgvector/pgvector:pg17
     environment:
       POSTGRES_DB: synergereader
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-    ports:
-      - "127.0.0.1:5432:5432"
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    expose:
+      - "5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d synergereader"]
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
       interval: 5s
       timeout: 5s
       retries: 10
     restart: unless-stopped
+
   backend:
     build:
       context: ./synerge-reader-backend
       dockerfile: Dockerfile
     ports:
-      - "5000:5000"
+      - "127.0.0.1:5000:5000"
     volumes:
       - ./synerge-reader-backend:/app
       - chroma_data:/app/chroma_db
     environment:
       - PYTHONUNBUFFERED=1
-      - OLLAMA_BASE_URL=http://ollama:11434
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL}
       - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - DB_CONNECTION_STRING=${DB_CONNECTION_STRING}
       - EMAIL_KEY=${EMAIL_KEY}
     depends_on:
-      ollama:
-        condition: service_started
-      db:
+      synergereader-db:
         condition: service_healthy
     restart: unless-stopped
+
   frontend:
     build:
       context: ./synerge-reader-frontend
@@ -58,13 +52,14 @@ services:
         - REACT_APP_BACKEND_URL=${REACT_APP_BACKEND_URL}
         - REACT_APP_GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     volumes:
       - ./synerge-reader-frontend:/app
       - /app/node_modules
     depends_on:
       - backend
     restart: unless-stopped
+
   nginx:
     image: nginx:alpine
     container_name: nginx-proxy
@@ -78,7 +73,8 @@ services:
       - frontend
       - backend
     restart: unless-stopped
+
 volumes:
   chroma_data:
-  ollama_data:
-  pgdata:
+  db_data:
+  


### PR DESCRIPTION
## What this PR does

**Fixes deployment failure from PR #45**
- Removes Ollama from docker-compose — system Ollama already running on DGX server using GPU (confirmed via nvidia-smi)
- Backend connects to system Ollama via 172.18.0.1:11434 (Docker bridge gateway, confirmed for agent_network)

**PostgreSQL — Docker internal only**
- Keeps PostgreSQL in Docker but removes host port binding
- Uses expose: "5432" so only reachable by backend container internally
- No conflict with system PostgreSQL on port 5432
- Database created automatically on first startup

**Task 4 — Port security**
- Frontend port 3000 restricted to 127.0.0.1 (localhost only)
- Backend port 5000 restricted to 127.0.0.1 (localhost only)
- Ports no longer directly accessible from UNT network

**Other improvements**
- Project name pinned via name: synergereader — prevents volume naming issues across deployments
- DB credentials use environment variables — no hardcoding
- Healthcheck uses $$ variable expansion inside container
- Updated .gitignore with Python, eval, and local file exclusions

## Deployment note
Before merging and deploying, the backup stack must be brought down first:
cd /mnt/2025-legalread/repo-backup && docker-compose down