### PR TITLE
fix: move nginx origin to loopback port 8443

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,9 @@ services:
     image: nginx:alpine
     container_name: nginx-proxy
     ports:
-      - "80:80"
-      - "443:443"
+      # Host port 443 is used by another project on the shared DGX.
+      # Must match the Cloudflare Tunnel origin in /etc/cloudflared/config.yml.
+      - "127.0.0.1:8443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - /var/www/certbot:/var/www/certbot:ro


### PR DESCRIPTION
## Summary

Align the nginx configuration in the repository with the working
production configuration.

## Problem

Another service on the shared host already occupies port 443, preventing
the SynergeReader nginx container from starting with its previous port
mapping.

## Change

Replace:

```yaml
ports:
  - "80:80"
  - "443:443"
```

With:

```yaml
ports:
  # Host port 443 is used by another project on the shared DGX.
  # Must match the Cloudflare Tunnel origin in /etc/cloudflared/config.yml.
  - "127.0.0.1:8443:443"
```

The Cloudflare Tunnel already forwards requests to the new local port.

## Scope

Only the nginx port mapping in `docker-compose.yml` is changed.